### PR TITLE
Work around issues with 0-size files in package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# isc.perf.ui
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased - 1.0.x]
+
+### Added 
+-
+
+### Changed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+### Removed
+-
+
+### Deprecated
+-
+
+## [1.0.1] - 2022-06-21
+### Fixed
+- Works around issue with empty CSS files and zpm/zpm-registry (fixes installation from remote registry)
+
+## [1.0.0] - 2022-06-21
+- First released version
+

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="isc.perf.ui.ZPM">
     <Module>
       <Name>isc.perf.ui</Name>
-      <Version>1.0.0</Version>
+      <Version>1.0.1</Version>
       <Description>Provides visual representation of %SYS.MONLBL results</Description>
       <Keywords>performance monitor</Keywords>
       <Packaging>module</Packaging>

--- a/ng/monlbl-viewer/src/app/app.component.css
+++ b/ng/monlbl-viewer/src/app/app.component.css
@@ -1,0 +1,1 @@
+/* Intentionally left blank */

--- a/ng/monlbl-viewer/src/app/core/components/home/home.component.css
+++ b/ng/monlbl-viewer/src/app/core/components/home/home.component.css
@@ -1,0 +1,1 @@
+/* Intentionally left blank */

--- a/ng/monlbl-viewer/src/app/core/components/launcher/launcher.component.css
+++ b/ng/monlbl-viewer/src/app/core/components/launcher/launcher.component.css
@@ -1,0 +1,1 @@
+/* Intentionally left blank */


### PR DESCRIPTION
CSS files weren't reconstituted in decompression (I think) - this will fix installation.